### PR TITLE
1.4.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,11 +32,11 @@ rustdoc-args = ["--cfg", "docsrs"]
 
 [features]
 default = [
-	"contract", 
-	"transmute-inline", 
-	"error_details", 
-	"compatible_stdapi", 
-	"support_size_check_transmute"
+	"contract",
+	"transmute-inline",
+	"error_details",
+	"compatible_stdapi",
+	"support_size_check_transmute",
 ]
 
 # includes `contract.rs` api.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,6 +37,7 @@ default = [
 	"error_details",
 	"compatible_stdapi",
 	"support_size_check_transmute",
+	"require_debug_assert_transmute"
 ]
 
 # includes `contract.rs` api.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,7 +36,7 @@ default = [
 	"transmute-inline",
 	"error_details",
 	"compatible_stdapi",
-	"support_size_check_transmute",
+	"try_transmute",
 	"assert_transmute_mode"
 ]
 
@@ -51,11 +51,11 @@ transmute-inline = []
 transmute-inline-always = []
 
 # includes `try_transmute_or_panic`, `try_transmute` api.
-support_size_check_transmute = []
+try_transmute = []
 
 # Add transmutation checks regardless of the selected function, 
 # only works when `debug_assert` is active
-assert_transmute_mode = ["support_size_check_transmute"]
+assert_transmute_mode = [ "try_transmute" ]
 
 # includes `to.rs` api.
 to = []

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cluFullTransmute"
-version = "1.4.0"
+version = "1.4.1"
 authors = ["Denis Kotlyarov (Денис Котляров) <denis2005991@gmail.com>"]
 repository = "https://github.com/clucompany/cluFullTransmute.git"
 edition = "2024"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,7 +37,7 @@ default = [
 	"error_details",
 	"compatible_stdapi",
 	"support_size_check_transmute",
-	"require_debug_assert_transmute"
+	"assert_transmute_mode"
 ]
 
 # includes `contract.rs` api.
@@ -55,7 +55,7 @@ support_size_check_transmute = []
 
 # Add transmutation checks regardless of the selected function, 
 # only works when `debug_assert` is active
-require_debug_assert_transmute = ["support_size_check_transmute"]
+assert_transmute_mode = ["support_size_check_transmute"]
 
 # includes `to.rs` api.
 to = []

--- a/src/err.rs
+++ b/src/err.rs
@@ -23,6 +23,11 @@ pub struct TransmuteErr<T> {
 pub enum TransmuteErrKind {
 	/// Mismatch in input/output type sizes (e.g. `size_of::<A>() != size_of::<B>()`)
 	SizeMismatch { atype: usize, btype: usize },
+
+	/// Mismatch in input/output type sizes (e.g. `size_of::<A>() != size_of::<B>()`)
+	/// in debug_assertions.
+	#[cfg(all(feature = "require_debug_assert_transmute", debug_assertions))]
+	SizeMismatchInDebugAssert { atype: usize, btype: usize },
 }
 
 impl TransmuteErrKind {
@@ -33,10 +38,25 @@ impl TransmuteErrKind {
 		Self::SizeMismatch { atype, btype }
 	}
 
+	/// An error occurred while comparing the sizes of input and output types
+	/// (sizeA is not equal to sizeB).
+	#[cfg(all(feature = "require_debug_assert_transmute", debug_assertions))]
+	#[inline]
+	pub const fn size_mismatch_in_debug_assert(atype: usize, btype: usize) -> Self {
+		Self::SizeMismatchInDebugAssert { atype, btype }
+	}
+
 	/// Whether the current cause of the error is related to the inequality
 	/// of data dimensions at the input and output.
 	#[inline]
 	pub const fn is_size_mismatch(&self) -> bool {
+		#[cfg(all(feature = "require_debug_assert_transmute", debug_assertions))]
+		return matches!(
+			self,
+			Self::SizeMismatch { .. } | Self::SizeMismatchInDebugAssert { .. }
+		);
+
+		#[cfg(not(all(feature = "require_debug_assert_transmute", debug_assertions)))]
 		matches!(self, Self::SizeMismatch { .. })
 	}
 
@@ -151,6 +171,10 @@ mod stderr {
 				TransmuteErrKind::SizeMismatch { .. } => {
 					"TransmuteErrKind::SizeMismatch(atype != bsize)"
 				}
+				#[cfg(all(feature = "require_debug_assert_transmute", debug_assertions))]
+				TransmuteErrKind::SizeMismatchInDebugAssert { .. } => {
+					"TransmuteErrKind::SizeMismatch(atype != bsize)"
+				}
 			}
 		}
 	}
@@ -173,14 +197,24 @@ mod error_details {
 				+ usize::MAX_DECIMAL_LEN // usize
 				+ DESCRIPTION_S1.len() // str
 				+ usize::MAX_DECIMAL_LEN // usize
-				+ DESCRIPTION_S2.len(); // str
+				+ DESCRIPTION_S2.len() + { // str
+					#[cfg(all(feature = "require_debug_assert_transmute", debug_assertions))]
+					{DESCRIPTION_S3.len()}
+					#[cfg(not(all(feature = "require_debug_assert_transmute", debug_assertions)))]
+					0
+				};
 	const DESCRIPTION_S0: &str = "Invalid transmute: attempted to reinterpret type A (";
 	const DESCRIPTION_S1: &str = " bytes) as incompatible type B (";
 	const DESCRIPTION_S2: &str = " bytes). Sizes must match exactly.";
+
+	#[cfg(all(feature = "require_debug_assert_transmute", debug_assertions))]
+	const DESCRIPTION_S3: &str = "This check was added additionally due to the inclusion of `debug_assertions` and the `require_debug_assert_transmute` function in `cluFullTransmute`.";
 	/// Creates a formatted error description in const mode.
 	pub(crate) const fn as_description(kind: TransmuteErrKind) -> DescriptionOut {
-		let (a_size, b_size) = match kind {
-			TransmuteErrKind::SizeMismatch { atype, btype } => (atype, btype),
+		let (a_size, b_size, adebug_assert) = match kind {
+			TransmuteErrKind::SizeMismatch { atype, btype } => (atype, btype, false),
+			#[cfg(all(feature = "require_debug_assert_transmute", debug_assertions))]
+			TransmuteErrKind::SizeMismatchInDebugAssert { atype, btype } => (atype, btype, true),
 		};
 
 		let mut buf = ConstStrBuf::new();
@@ -193,6 +227,12 @@ mod error_details {
 		buf.push_str(DESCRIPTION_S1);
 		buf.push_usize(b_size);
 		buf.push_str(DESCRIPTION_S2);
+
+		if adebug_assert {
+			#[cfg(all(feature = "require_debug_assert_transmute", debug_assertions))]
+			buf.push_str(DESCRIPTION_S3);
+			let _e = adebug_assert;
+		}
 
 		buf
 	}
@@ -242,6 +282,10 @@ mod error_details {
 		match kind {
 			TransmuteErrKind::SizeMismatch { .. } => {
 				Str::new("TransmuteErrKind::SizeMismatch(asize != bsize)")
+			}
+			#[cfg(all(feature = "require_debug_assert_transmute", debug_assertions))]
+			TransmuteErrKind::SizeMismatch { .. } => {
+				Str::new("TransmuteErrKind::SizeMismatchInDebugAssert(asize != bsize)")
 			}
 		}
 	}

--- a/src/err.rs
+++ b/src/err.rs
@@ -240,7 +240,7 @@ mod error_details {
 	/// Creates a formatted error description in const mode.
 	pub(crate) const fn as_description(kind: TransmuteErrKind) -> DescriptionOut {
 		match kind {
-			TransmuteErrKind::SizeMismatch(..) => {
+			TransmuteErrKind::SizeMismatch { .. } => {
 				Str::new("TransmuteErrKind::SizeMismatch(asize != bsize)")
 			}
 		}

--- a/src/err.rs
+++ b/src/err.rs
@@ -26,7 +26,7 @@ pub enum TransmuteErrKind {
 
 	/// Mismatch in input/output type sizes (e.g. `size_of::<A>() != size_of::<B>()`)
 	/// in debug_assertions.
-	#[cfg(all(feature = "require_debug_assert_transmute", debug_assertions))]
+	#[cfg(all(feature = "assert_transmute_mode", debug_assertions))]
 	SizeMismatchInDebugAssert { atype: usize, btype: usize },
 }
 
@@ -40,7 +40,7 @@ impl TransmuteErrKind {
 
 	/// An error occurred while comparing the sizes of input and output types
 	/// (sizeA is not equal to sizeB).
-	#[cfg(all(feature = "require_debug_assert_transmute", debug_assertions))]
+	#[cfg(all(feature = "assert_transmute_mode", debug_assertions))]
 	#[inline]
 	pub const fn size_mismatch_in_debug_assert(atype: usize, btype: usize) -> Self {
 		Self::SizeMismatchInDebugAssert { atype, btype }
@@ -50,13 +50,13 @@ impl TransmuteErrKind {
 	/// of data dimensions at the input and output.
 	#[inline]
 	pub const fn is_size_mismatch(&self) -> bool {
-		#[cfg(all(feature = "require_debug_assert_transmute", debug_assertions))]
+		#[cfg(all(feature = "assert_transmute_mode", debug_assertions))]
 		return matches!(
 			self,
 			Self::SizeMismatch { .. } | Self::SizeMismatchInDebugAssert { .. }
 		);
 
-		#[cfg(not(all(feature = "require_debug_assert_transmute", debug_assertions)))]
+		#[cfg(not(all(feature = "assert_transmute_mode", debug_assertions)))]
 		matches!(self, Self::SizeMismatch { .. })
 	}
 
@@ -171,7 +171,7 @@ mod stderr {
 				TransmuteErrKind::SizeMismatch { .. } => {
 					"TransmuteErrKind::SizeMismatch(atype != bsize)"
 				}
-				#[cfg(all(feature = "require_debug_assert_transmute", debug_assertions))]
+				#[cfg(all(feature = "assert_transmute_mode", debug_assertions))]
 				TransmuteErrKind::SizeMismatchInDebugAssert { .. } => {
 					"TransmuteErrKind::SizeMismatch(atype != bsize)"
 				}
@@ -198,22 +198,22 @@ mod error_details {
 				+ DESCRIPTION_S1.len() // str
 				+ usize::MAX_DECIMAL_LEN // usize
 				+ DESCRIPTION_S2.len() + { // str
-					#[cfg(all(feature = "require_debug_assert_transmute", debug_assertions))]
+					#[cfg(all(feature = "assert_transmute_mode", debug_assertions))]
 					{DESCRIPTION_S3.len()}
-					#[cfg(not(all(feature = "require_debug_assert_transmute", debug_assertions)))]
+					#[cfg(not(all(feature = "assert_transmute_mode", debug_assertions)))]
 					0
 				};
 	const DESCRIPTION_S0: &str = "Invalid transmute: attempted to reinterpret type A (";
 	const DESCRIPTION_S1: &str = " bytes) as incompatible type B (";
 	const DESCRIPTION_S2: &str = " bytes). Sizes must match exactly.";
 
-	#[cfg(all(feature = "require_debug_assert_transmute", debug_assertions))]
-	const DESCRIPTION_S3: &str = "This check was added additionally due to the inclusion of `debug_assertions` and the `require_debug_assert_transmute` function in `cluFullTransmute`.";
+	#[cfg(all(feature = "assert_transmute_mode", debug_assertions))]
+	const DESCRIPTION_S3: &str = "This check was added additionally due to the inclusion of `debug_assertions` and the `assert_transmute_mode` function in `cluFullTransmute`.";
 	/// Creates a formatted error description in const mode.
 	pub(crate) const fn as_description(kind: TransmuteErrKind) -> DescriptionOut {
 		let (a_size, b_size, adebug_assert) = match kind {
 			TransmuteErrKind::SizeMismatch { atype, btype } => (atype, btype, false),
-			#[cfg(all(feature = "require_debug_assert_transmute", debug_assertions))]
+			#[cfg(all(feature = "assert_transmute_mode", debug_assertions))]
 			TransmuteErrKind::SizeMismatchInDebugAssert { atype, btype } => (atype, btype, true),
 		};
 
@@ -229,7 +229,7 @@ mod error_details {
 		buf.push_str(DESCRIPTION_S2);
 
 		if adebug_assert {
-			#[cfg(all(feature = "require_debug_assert_transmute", debug_assertions))]
+			#[cfg(all(feature = "assert_transmute_mode", debug_assertions))]
 			buf.push_str(DESCRIPTION_S3);
 			let _e = adebug_assert;
 		}
@@ -283,7 +283,7 @@ mod error_details {
 			TransmuteErrKind::SizeMismatch { .. } => {
 				Str::new("TransmuteErrKind::SizeMismatch(asize != bsize)")
 			}
-			#[cfg(all(feature = "require_debug_assert_transmute", debug_assertions))]
+			#[cfg(all(feature = "assert_transmute_mode", debug_assertions))]
 			TransmuteErrKind::SizeMismatch { .. } => {
 				Str::new("TransmuteErrKind::SizeMismatchInDebugAssert(asize != bsize)")
 			}

--- a/src/err.rs
+++ b/src/err.rs
@@ -282,11 +282,11 @@ mod error_details {
 		match kind {
 			TransmuteErrKind::SizeMismatch { .. } => {
 				Str::new("TransmuteErrKind::SizeMismatch(asize != bsize)")
-			}
+			},
 			#[cfg(all(feature = "assert_transmute_mode", debug_assertions))]
-			TransmuteErrKind::SizeMismatch { .. } => {
+			TransmuteErrKind::SizeMismatchInDebugAssert { .. } => {
 				Str::new("TransmuteErrKind::SizeMismatchInDebugAssert(asize != bsize)")
-			}
+			},
 		}
 	}
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -65,8 +65,8 @@ pub mod mem {
 	pub use crate::try_transmute_or_panic as transmute;
 }
 
-#[cfg_attr(docsrs, doc(cfg(feature = "support_size_check_transmute")))]
-#[cfg(any(test, feature = "support_size_check_transmute"))]
+#[cfg_attr(docsrs, doc(cfg(feature = "try_transmute")))]
+#[cfg(any(test, feature = "try_transmute"))]
 pub mod err;
 mod raw;
 
@@ -78,8 +78,8 @@ pub mod to;
 #[cfg(any(test, feature = "contract"))]
 pub mod contract;
 
-#[cfg_attr(docsrs, doc(cfg(feature = "support_size_check_transmute")))]
-#[cfg(any(test, feature = "support_size_check_transmute"))]
+#[cfg_attr(docsrs, doc(cfg(feature = "try_transmute")))]
+#[cfg(any(test, feature = "try_transmute"))]
 use crate::err::TransmuteErr;
 pub use crate::raw::transmute_unchecked;
 
@@ -94,8 +94,8 @@ pub use crate::raw::transmute_unchecked;
 	inline
 )]
 #[cfg_attr(feature = "transmute-inline-always", inline(always))]
-#[cfg_attr(docsrs, doc(cfg(feature = "support_size_check_transmute")))]
-#[cfg(any(test, feature = "support_size_check_transmute"))]
+#[cfg_attr(docsrs, doc(cfg(feature = "try_transmute")))]
+#[cfg(any(test, feature = "try_transmute"))]
 pub const unsafe fn try_transmute_or_panic<D, To>(in_data: D) -> To {
 	use crate::err::TransmuteErrKind;
 	pub use crate::raw::transmute_unchecked;
@@ -125,8 +125,8 @@ pub const unsafe fn try_transmute_or_panic<D, To>(in_data: D) -> To {
 	inline
 )]
 #[cfg_attr(feature = "transmute-inline-always", inline(always))]
-#[cfg_attr(docsrs, doc(cfg(feature = "support_size_check_transmute")))]
-#[cfg(any(test, feature = "support_size_check_transmute"))]
+#[cfg_attr(docsrs, doc(cfg(feature = "try_transmute")))]
+#[cfg(any(test, feature = "try_transmute"))]
 pub const unsafe fn try_transmute<D, To>(in_data: D) -> Result<To, TransmuteErr<D>> {
 	pub use crate::raw::transmute_unchecked;
 	use core::mem::size_of;

--- a/src/raw.rs
+++ b/src/raw.rs
@@ -29,7 +29,7 @@ pub const unsafe fn transmute_unchecked<T, To>(in_data: T) -> To {
 		let size_to = size_of::<To>();
 
 		if size_d != size_to {
-			let errkind = TransmuteErrKind::size_mismatch(size_d, size_to);
+			let errkind = TransmuteErrKind::size_mismatch_in_debug_assert(size_d, size_to);
 
 			errkind.unwrap();
 		}

--- a/src/raw.rs
+++ b/src/raw.rs
@@ -21,7 +21,7 @@ union TransmutData<In, Out> {
 pub const unsafe fn transmute_unchecked<T, To>(in_data: T) -> To {
 	// Add transmutation checks regardless of the selected function,
 	// only works when `debug_assert` is active
-	#[cfg(all(feature = "require_debug_assert_transmute", debug_assertions))]
+	#[cfg(all(feature = "assert_transmute_mode", debug_assertions))]
 	{
 		use crate::err::TransmuteErrKind;
 

--- a/src/to.rs
+++ b/src/to.rs
@@ -12,8 +12,8 @@ where
 	/// # Safety
 	///
 	/// If the sizes do not match, a panic arises.
-	#[cfg_attr(docsrs, doc(cfg(feature = "support_size_check_transmute")))]
-	#[cfg(any(test, feature = "support_size_check_transmute"))]
+	#[cfg_attr(docsrs, doc(cfg(feature = "try_transmute")))]
+	#[cfg(any(test, feature = "try_transmute"))]
 	unsafe fn try_transmute_or_panic<To>(self) -> To;
 
 	/// A constant function reinterprets the bits of a value of one type as another type.
@@ -21,8 +21,8 @@ where
 	/// # Safety
 	///
 	/// If the size does not match, an error occurs.
-	#[cfg_attr(docsrs, doc(cfg(feature = "support_size_check_transmute")))]
-	#[cfg(any(test, feature = "support_size_check_transmute"))]
+	#[cfg_attr(docsrs, doc(cfg(feature = "try_transmute")))]
+	#[cfg(any(test, feature = "try_transmute"))]
 	unsafe fn try_transmute<To>(self) -> Result<To, TransmuteErr<Self>>;
 
 	/// Reinterprets the bits of a value of one type as another type.
@@ -42,8 +42,8 @@ where
 	/// # Safety
 	///
 	/// If the sizes do not match, a panic arises.
-	#[cfg_attr(docsrs, doc(cfg(feature = "support_size_check_transmute")))]
-	#[cfg(any(test, feature = "support_size_check_transmute"))]
+	#[cfg_attr(docsrs, doc(cfg(feature = "try_transmute")))]
+	#[cfg(any(test, feature = "try_transmute"))]
 	#[cfg_attr(
 		all(feature = "transmute-inline", not(feature = "transmute-inline-always")),
 		inline
@@ -58,8 +58,8 @@ where
 	/// # Safety
 	///
 	/// If the size does not match, an error occurs.
-	#[cfg_attr(docsrs, doc(cfg(feature = "support_size_check_transmute")))]
-	#[cfg(any(test, feature = "support_size_check_transmute"))]
+	#[cfg_attr(docsrs, doc(cfg(feature = "try_transmute")))]
+	#[cfg(any(test, feature = "try_transmute"))]
 	#[cfg_attr(
 		all(feature = "transmute-inline", not(feature = "transmute-inline-always")),
 		inline


### PR DESCRIPTION
1.4.1
=================
- feat: Improved error message to show that this check was triggered due to `debug_assert` being enabled and the enable `require_debug_assert_transmute` flag.
- feat: enable additional debug checks by default on standard unsafe transmute
- fix: fix build error that occurs with non-standard configuration
- refactor: rename feature `support_size_check_transmute` to `try_transmute`
- refactor: rename enable flag `require_debug_assert_transmute` to `assert_transmute_mode`
- build: update library version to `1.4.1`